### PR TITLE
Limit workflow trigger to project owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The following input variables are used by the action:
 
 To include this Github action in your own repository, you can use the following example in your workflow file:
 
+  # Only run the action if the issue is created by the repository owner
+  if: github.event.issue.user.login == github.repository_owner
+
 ```yaml
 on:
   issues:

--- a/workflows/create-pr-from-issue.yml
+++ b/workflows/create-pr-from-issue.yml
@@ -1,0 +1,6 @@
+      - name: Check if issue is created by owner
+        run: |
+          if [ "${{ github.event.issue.user.login }}" != "${{ github.repository_owner }}" ]; then
+            echo "Issue not created by the owner. Skipping action.";
+            exit 78;
+          fi


### PR DESCRIPTION
This pull request adds a condition to the GitHub action workflow that allows it to be triggered only when the project owner creates or edits an issue.

Pseudocode:
- Add `if` condition in the workflow file to check for project owner
- Update the example in README.md

Fixes #1